### PR TITLE
ci: sign and notarize macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,6 @@ jobs:
             artifact: macos-arm64
 
     runs-on: ${{ matrix.runner }}
-    env:
-      CSC_IDENTITY_AUTO_DISCOVERY: "false"
 
     steps:
       - name: Check out repository
@@ -71,6 +69,20 @@ jobs:
 
       - name: Run syntax checks
         run: npm run check
+
+      - name: Configure macOS signing
+        if: runner.os == 'macOS'
+        run: |
+          if [ -n "${{ secrets.MAC_CSC_LINK }}" ]; then
+            echo "CSC_LINK=${{ secrets.MAC_CSC_LINK }}" >> "$GITHUB_ENV"
+            echo "CSC_KEY_PASSWORD=${{ secrets.MAC_CSC_KEY_PASSWORD }}" >> "$GITHUB_ENV"
+            APPLE_API_KEY_FILE="$RUNNER_TEMP/AuthKey.p8"
+            echo "${{ secrets.APPLE_API_KEY }}" | base64 --decode > "$APPLE_API_KEY_FILE"
+            echo "APPLE_API_KEY=$APPLE_API_KEY_FILE" >> "$GITHUB_ENV"
+            echo "APPLE_API_KEY_ID=${{ secrets.APPLE_API_KEY_ID }}" >> "$GITHUB_ENV"
+            echo "APPLE_API_ISSUER=${{ secrets.APPLE_API_ISSUER }}" >> "$GITHUB_ENV"
+            echo "APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}" >> "$GITHUB_ENV"
+          fi
 
       - name: Build packages
         run: npm run ${{ matrix.script }} -- ${{ matrix.arch }}

--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -77,10 +77,14 @@
       "artifactName": "DSH-Desktop-v${version}-macos-${arch}.${ext}",
       "target": [
         "dmg"
-      ]
+      ],
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.inherit.plist",
+      "notarize": true
     },
     "dmg": {
-      "sign": false,
+      "sign": true,
       "contents": [
         {
           "x": 130,


### PR DESCRIPTION
## What

The macOS DMG in GitHub Releases is currently unsigned and unnotarized, so Gatekeeper blocks it on first launch with "cannot verify the developer".

This PR enables macOS code signing (Developer ID) and notarization in CI.

## Changes

- `package.json` (`build.mac`): enable `hardenedRuntime`, add `entitlements`/`entitlementsInherit`, set `notarize: true`; enable DMG signing (`dmg.sign: true`).
- Add `build/entitlements.mac.plist` and `build/entitlements.mac.inherit.plist` (Electron-required `allow-jit` + `allow-unsigned-executable-memory`).
- `.github/workflows/build.yml`: remove `CSC_IDENTITY_AUTO_DISCOVERY: "false"`; inject signing/notarization secrets on macOS only, guarded so fork PRs without secrets fall back to unsigned builds (no CI breakage).

## Maintainer setup (required for signed releases)

Add these repo secrets (`Settings -> Secrets and variables -> Actions`):

| Secret | Value |
| --- | --- |
| `MAC_CSC_LINK` | base64 of a Developer ID Application `.p12` |
| `MAC_CSC_KEY_PASSWORD` | `.p12` export password |
| `APPLE_API_KEY` | base64 of an App Store Connect API key `.p8` |
| `APPLE_API_KEY_ID` | key ID |
| `APPLE_API_ISSUER` | issuer ID |
| `APPLE_TEAM_ID` | team ID |

Requires an Apple Developer Program membership and a "Developer ID Application" certificate (not "Apple Distribution"). Without the secrets the build stays unsigned exactly as today.
