### PR TITLE
Add in-app auto-update with a session-header button

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,15 @@ jobs:
           if ($setup.Count -ne 1) { throw "Expected one Windows setup package, found $($setup.Count)" }
           if ($portable.Count -ne 1) { throw "Expected one Windows portable package, found $($portable.Count)" }
 
+      - name: Verify macOS package variants
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          dmg=$(find dist -maxdepth 1 -name '*.dmg' | wc -l | tr -d ' ')
+          zip=$(find dist -maxdepth 1 -name '*.zip' | wc -l | tr -d ' ')
+          if [ "$dmg" -ne 1 ]; then echo "Expected one dmg, found $dmg" >&2; exit 1; fi
+          if [ "$zip" -ne 1 ]; then echo "Expected one zip, found $zip" >&2; exit 1; fi
+
       - name: Upload packages
         uses: actions/upload-artifact@v7
         with:
@@ -105,6 +114,8 @@ jobs:
             dist/*.AppImage
             dist/*.dmg
             dist/*.exe
+            dist/*.zip
+            dist/*.yml
 
   release:
     name: Publish GitHub Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@deepseek-ai/dsh-workflow": "0.1.0-rc.8",
         "dsh-file-viewer": "github:liguobao/dsh-file-viewer#v0.2.3",
         "dsh-remote": "github:liguobao/deepseek-harness-remote#v0.3.21",
+        "electron-updater": "^6.8.9",
         "pnpm": "11.21.0",
         "semver": "7.7.3",
         "yaml": "2.9.0"
@@ -7091,7 +7092,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -7988,6 +7988,22 @@
         "mime": "^2.5.2"
       }
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -8448,7 +8464,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -8733,7 +8748,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -9283,7 +9297,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -9374,7 +9387,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkify-it": {
@@ -9401,6 +9413,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -10796,7 +10821,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -11275,6 +11299,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -11471,7 +11501,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "check": "node --check src/main.js && node --check src/auto-update.js && node --check src/dsh-runtime.js && node --check src/dsh-update.js && node --check src/desktop-integration.js && node --check src/harness-server.js && node --check src/navigation.js && node --check src/plugin-catalog.js && node --check src/plugin-management.js && node --check src/startup-progress.js && node --check src/parent-watch.cjs && node --check src/preload.cjs && node --check src/plugin-preload.cjs && node --check src/pages/manager-ui.js && node --check src/pages/plugins-page.js && node --check src/plugins/dsh-desktop-integration/lib/index.js && node --check src/plugins/dsh-desktop-integration/lib/client.js && node --check scripts/generate-plugin-catalog.mjs",
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage --publish never",
-    "dist:mac": "electron-builder --mac dmg --publish never",
+    "dist:mac": "electron-builder --mac dmg zip --publish never",
     "dist:windows": "electron-builder --win --publish never"
   },
   "dependencies": {
@@ -47,6 +47,7 @@
     "@deepseek-ai/dsh-workflow": "0.1.0-rc.8",
     "dsh-file-viewer": "github:liguobao/dsh-file-viewer#v0.2.3",
     "dsh-remote": "github:liguobao/deepseek-harness-remote#v0.3.21",
+    "electron-updater": "^6.8.9",
     "pnpm": "11.21.0",
     "semver": "7.7.3",
     "yaml": "2.9.0"
@@ -59,6 +60,11 @@
   "build": {
     "appId": "io.github.dshdesktop.app",
     "productName": "DSH Desktop",
+    "publish": {
+      "provider": "github",
+      "owner": "liguobao",
+      "repo": "dsh-desktop"
+    },
     "asar": false,
     "npmRebuild": false,
     "files": [
@@ -76,7 +82,8 @@
       "icon": "build/icon.png",
       "artifactName": "DSH-Desktop-v${version}-macos-${arch}.${ext}",
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ],
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",

--- a/src/auto-update.js
+++ b/src/auto-update.js
@@ -1,203 +1,29 @@
-import { createHash } from 'node:crypto'
-import { access, chmod, mkdir, open, rm } from 'node:fs/promises'
-import { basename, extname, join } from 'node:path'
-import semver from 'semver'
-
 const REPOSITORY = 'liguobao/dsh-desktop'
 export const RELEASES_URL = `https://github.com/${REPOSITORY}/releases/latest`
-export const LATEST_RELEASE_API_URL = `https://api.github.com/repos/${REPOSITORY}/releases/latest`
 
-function updateCopy(isChinese, platform) {
-  const revealOnly = platform === 'linux'
+function updateCopy(isChinese) {
   return isChinese ? {
-      check: '检查更新…',
-      checking: '正在检查更新…',
-      downloading: progress => `正在下载安装包… ${String(progress)}%`,
-      available: version => `可下载 v${version}`,
-      downloaded: revealOnly ? '显示已下载的 AppImage…' : '打开已下载的安装包…',
-      releases: '查看最新版本…',
-      availableTitle: '发现新版本',
-      availableMessage: version => `DSH Desktop ${version} 已发布`,
-      availableDetail: current => `当前版本为 ${current}。是否将安装包下载到系统“下载”目录？`,
-      download: '下载安装包',
-      later: '稍后',
-      readyTitle: '安装包已下载',
-      readyMessage: version => `DSH Desktop ${version} 已保存到本地`,
-      readyDetail: path => revealOnly
-        ? `文件位于 ${path}。请退出应用后，用它替换当前 AppImage 并重新打开。`
-        : `文件位于 ${path}。请打开安装包，按系统提示完成更新。`,
-      open: revealOnly ? '在文件夹中显示' : '打开安装包',
-      noUpdateTitle: '已是最新版本',
-      noUpdateMessage: version => `DSH Desktop ${version} 已是最新版本。`,
-      failedTitle: '更新下载失败',
-      failedMessage: '无法下载 DSH Desktop 安装包。',
-    } : {
-      check: 'Check for Updates…',
-      checking: 'Checking for Updates…',
-      downloading: progress => `Downloading Installer… ${String(progress)}%`,
-      available: version => `Download v${version}`,
-      downloaded: revealOnly ? 'Show Downloaded AppImage…' : 'Open Downloaded Installer…',
-      releases: 'View Latest Release…',
-      availableTitle: 'Update Available',
-      availableMessage: version => `DSH Desktop ${version} is available`,
-      availableDetail: current => `You are using ${current}. Download the installer to your system Downloads folder?`,
-      download: 'Download Installer',
-      later: 'Later',
-      readyTitle: 'Installer Downloaded',
-      readyMessage: version => `DSH Desktop ${version} has been saved locally`,
-      readyDetail: path => revealOnly
-        ? `The file is at ${path}. Quit the app, replace the current AppImage with this file, and launch it again.`
-        : `The file is at ${path}. Open the installer and follow the system prompts to finish updating.`,
-      open: revealOnly ? 'Show in Folder' : 'Open Installer',
-      noUpdateTitle: 'You’re Up to Date',
-      noUpdateMessage: version => `DSH Desktop ${version} is the latest version.`,
-      failedTitle: 'Update Download Failed',
-      failedMessage: 'The DSH Desktop installer could not be downloaded.',
-    }
-}
-
-export function installerAssetName({ version, platform, arch }) {
-  if (semver.valid(version) !== version) throw new Error('Invalid release version')
-  if (platform === 'darwin' && ['arm64', 'x64'].includes(arch)) {
-    return `DSH-Desktop-v${version}-macos-${arch}.dmg`
-  }
-  if (platform === 'win32' && arch === 'x64') {
-    return `DSH-Desktop-v${version}-windows-${arch}-setup.exe`
-  }
-  if (platform === 'linux' && arch === 'x64') {
-    return `DSH-Desktop-v${version}-linux-${arch}.AppImage`
-  }
-  throw new Error(`No installer is published for ${platform}/${arch}`)
-}
-
-export function supportsInstallerDownloads({ isPackaged, platform, arch }) {
-  if (!isPackaged) return false
-  try {
-    installerAssetName({ version: '0.0.0', platform, arch })
-    return true
-  } catch {
-    return false
-  }
-}
-
-function validatedAssetUrl(url, tagName, assetName) {
-  const parsed = new URL(url)
-  const prefix = `/${REPOSITORY}/releases/download/${tagName}/`
-  if (parsed.protocol !== 'https:' || parsed.hostname !== 'github.com' || !parsed.pathname.startsWith(prefix)) {
-    throw new Error('Release asset URL is not trusted')
-  }
-  if (decodeURIComponent(parsed.pathname.slice(prefix.length)) !== assetName) {
-    throw new Error('Release asset URL does not match its file name')
-  }
-  return parsed.href
-}
-
-export function parseLatestRelease(release, { platform, arch }) {
-  if (release === null || typeof release !== 'object' || typeof release.tag_name !== 'string') {
-    throw new Error('GitHub returned an invalid Release')
-  }
-  if (release.draft === true || release.prerelease === true || !release.tag_name.startsWith('v')) {
-    throw new Error('GitHub returned an unsupported Release')
-  }
-  const version = release.tag_name.slice(1)
-  const name = installerAssetName({ version, platform, arch })
-  const asset = Array.isArray(release.assets)
-    ? release.assets.find(candidate => candidate?.name === name)
-    : undefined
-  if (asset === undefined || asset.state !== 'uploaded') throw new Error(`Release asset is missing: ${name}`)
-  if (!Number.isSafeInteger(asset.size) || asset.size <= 0) throw new Error('Release asset size is invalid')
-  if (typeof asset.digest !== 'string' || !/^sha256:[a-f0-9]{64}$/i.test(asset.digest)) {
-    throw new Error('Release asset has no valid SHA-256 digest')
-  }
-  return {
-    version,
-    asset: {
-      digest: asset.digest.toLowerCase(),
-      name,
-      size: asset.size,
-      url: validatedAssetUrl(asset.browser_download_url, release.tag_name, name),
-    },
-  }
-}
-
-async function pathExists(path) {
-  try {
-    await access(path)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function availableDownloadPath(directory, fileName) {
-  if (basename(fileName) !== fileName) throw new Error('Invalid installer file name')
-  const extension = extname(fileName)
-  const stem = fileName.slice(0, fileName.length - extension.length)
-  for (let index = 0; index < 10_000; index += 1) {
-    const suffix = index === 0 ? '' : ` (${String(index)})`
-    const candidate = join(directory, `${stem}${suffix}${extension}`)
-    if (!(await pathExists(candidate))) return candidate
-  }
-  throw new Error('Could not choose a local installer file name')
-}
-
-async function writeChunk(handle, chunk) {
-  const buffer = Buffer.from(chunk)
-  let offset = 0
-  while (offset < buffer.length) {
-    const result = await handle.write(buffer, offset, buffer.length - offset)
-    if (result.bytesWritten <= 0) throw new Error('Could not write the installer file')
-    offset += result.bytesWritten
-  }
-  return buffer
-}
-
-export async function downloadInstallerAsset({
-  asset,
-  downloadsDirectory,
-  fetchImpl,
-  platform,
-  signal,
-  onProgress = () => {},
-}) {
-  await mkdir(downloadsDirectory, { recursive: true })
-  const destination = await availableDownloadPath(downloadsDirectory, asset.name)
-  const response = await fetchImpl(asset.url, {
-    headers: { Accept: 'application/octet-stream' },
-    redirect: 'follow',
-    signal,
-  })
-  if (!response.ok) throw new Error(`GitHub download failed with HTTP ${String(response.status)}`)
-  if (response.body === null) throw new Error('GitHub download returned an empty response')
-
-  const handle = await open(destination, 'wx', 0o600)
-  const hash = createHash('sha256')
-  let received = 0
-  let completed = false
-  let lastProgress = -1
-  try {
-    for await (const chunk of response.body) {
-      const buffer = await writeChunk(handle, chunk)
-      hash.update(buffer)
-      received += buffer.length
-      if (received > asset.size) throw new Error('Downloaded installer is larger than the Release asset')
-      const progress = Math.min(100, Math.floor((received / asset.size) * 100))
-      if (progress !== lastProgress) {
-        lastProgress = progress
-        onProgress(progress)
-      }
-    }
-    await handle.sync()
-    if (received !== asset.size) throw new Error(`Installer size mismatch: expected ${String(asset.size)}, received ${String(received)}`)
-    const actualDigest = `sha256:${hash.digest('hex')}`
-    if (actualDigest !== asset.digest) throw new Error('Installer SHA-256 verification failed')
-    if (platform === 'linux') await chmod(destination, 0o755)
-    completed = true
-    if (lastProgress !== 100) onProgress(100)
-    return destination
-  } finally {
-    await handle.close()
-    if (!completed) await rm(destination, { force: true })
+    check: '检查更新…',
+    checking: '正在检查更新…',
+    downloading: progress => `正在下载更新… ${String(progress)}%`,
+    available: version => `下载 v${version}`,
+    downloaded: '重启以更新',
+    releases: '查看最新版本…',
+    noUpdateTitle: '已是最新版本',
+    noUpdateMessage: version => `DSH Desktop ${version} 已是最新版本。`,
+    failedTitle: '更新失败',
+    failedMessage: '无法检查或下载 DSH Desktop 更新。',
+  } : {
+    check: 'Check for Updates…',
+    checking: 'Checking for Updates…',
+    downloading: progress => `Downloading Update… ${String(progress)}%`,
+    available: version => `Download v${version}`,
+    downloaded: 'Restart to Update',
+    releases: 'View Latest Release…',
+    noUpdateTitle: 'You’re Up to Date',
+    noUpdateMessage: version => `DSH Desktop ${version} is the latest version.`,
+    failedTitle: 'Update Failed',
+    failedMessage: 'The DSH Desktop update could not be checked or downloaded.',
   }
 }
 
@@ -205,29 +31,28 @@ function errorDetail(error) {
   return error instanceof Error ? error.message : String(error)
 }
 
-export function createInstallerUpdateController({
+/**
+ * Drives the bundled electron-updater through a small state machine and shares
+ * it with both the Help menu and the session-header button. `updater` is the
+ * `autoUpdater` singleton from `electron-updater`, injected by the caller so
+ * this module stays importable from plain Node tests.
+ */
+export function createAutoUpdateController({
   isPackaged,
-  platform,
-  arch,
   isChinese,
   currentVersion,
-  downloadsDirectory,
-  fetchImpl,
+  updater,
+  openReleasePage,
   dialog,
   getWindow,
-  openReleasePage,
-  openDownloadedFile,
   onStateChange = () => {},
   log = () => {},
-  downloadImpl = downloadInstallerAsset,
 }) {
-  const copy = updateCopy(isChinese, platform)
-  const supported = supportsInstallerDownloads({ isPackaged, platform, arch })
+  const copy = updateCopy(isChinese)
+  const supported = isPackaged
   let state = supported ? 'idle' : 'unsupported'
   let progress = 0
   let targetVersion
-  let downloadedPath
-  let operationController
 
   function setState(next, details = {}) {
     state = next
@@ -236,11 +61,25 @@ export function createInstallerUpdateController({
     onStateChange()
   }
 
+  updater.autoDownload = false
+  updater.autoInstallOnAppQuit = true
+
+  updater.on('checking-for-update', () => setState('checking', { progress: 0 }))
+  updater.on('update-available', info => setState('available', { version: info.version }))
+  updater.on('update-not-available', () => setState('idle', { progress: 0 }))
+  updater.on('download-progress', info => setState('downloading', { progress: Math.round(info.percent) }))
+  updater.on('update-downloaded', info => setState('downloaded', { version: info.version, progress: 100 }))
+  updater.on('update-cancelled', () => setState('idle', { progress: 0 }))
+  updater.on('error', error => {
+    log('error', `Update failed: ${errorDetail(error)}`)
+    if (state !== 'downloaded') setState('idle', { progress: 0 })
+  })
+
   function menuItem() {
     if (!supported) return { label: copy.releases, enabled: true }
     if (state === 'checking') return { label: copy.checking, enabled: false }
     if (state === 'downloading') return { label: copy.downloading(progress), enabled: false }
-    if (state === 'available') return { label: copy.available(targetVersion), enabled: false }
+    if (state === 'available') return { label: copy.available(targetVersion), enabled: true }
     if (state === 'downloaded') return { label: copy.downloaded, enabled: true }
     return { label: copy.check, enabled: true }
   }
@@ -252,125 +91,60 @@ export function createInstallerUpdateController({
       : dialog.showMessageBox(options)
   }
 
-  async function showFailure(error, notify) {
-    const detail = errorDetail(error)
-    log('error', `Update download failed: ${detail}`)
-    setState(downloadedPath === undefined ? 'idle' : 'downloaded', { progress: 0 })
-    if (notify) {
-      await showMessage({
-        type: 'error',
-        title: copy.failedTitle,
-        message: copy.failedMessage,
-        detail,
-      })
-    }
-  }
-
-  async function promptDownloaded() {
-    if (downloadedPath === undefined) return
-    const result = await showMessage({
-      type: 'info',
-      title: copy.readyTitle,
-      message: copy.readyMessage(targetVersion ?? currentVersion),
-      detail: copy.readyDetail(downloadedPath),
-      buttons: [copy.open, copy.later],
-      defaultId: 0,
-      cancelId: 1,
-      noLink: true,
-    })
-    if (result.response !== 0) return
-    try {
-      const error = await openDownloadedFile(downloadedPath)
-      if (typeof error === 'string' && error !== '') throw new Error(error)
-    } catch (error) {
-      await showFailure(error, true)
-    }
-  }
-
-  async function fetchLatestRelease(signal) {
-    const response = await fetchImpl(LATEST_RELEASE_API_URL, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-      signal,
-    })
-    if (!response.ok) throw new Error(`GitHub Release check failed with HTTP ${String(response.status)}`)
-    return parseLatestRelease(await response.json(), { platform, arch })
-  }
-
   async function check(manual = false) {
     if (!supported) {
       if (manual) await openReleasePage(RELEASES_URL)
       return
     }
+    if (state === 'checking' || state === 'downloading') return
     if (state === 'downloaded') {
-      if (manual) await promptDownloaded()
+      if (manual) restart()
       return
     }
-    if (state !== 'idle') return
-    setState('checking', { progress: 0 })
-    operationController = new AbortController()
-    let interactive = false
     try {
-      const release = await fetchLatestRelease(operationController.signal)
-      if (!semver.gt(release.version, currentVersion)) {
-        setState('idle', { progress: 0 })
-        if (manual) {
-          await showMessage({
-            type: 'info',
-            title: copy.noUpdateTitle,
-            message: copy.noUpdateMessage(currentVersion),
-          })
-        }
-        return
+      const result = await updater.checkForUpdates()
+      if (manual && (result === null || !result.isUpdateAvailable)) {
+        await showMessage({
+          type: 'info',
+          title: copy.noUpdateTitle,
+          message: copy.noUpdateMessage(currentVersion),
+        })
       }
-      targetVersion = release.version
-      setState('available', { version: release.version })
-      const result = await showMessage({
-        type: 'info',
-        title: copy.availableTitle,
-        message: copy.availableMessage(release.version),
-        detail: copy.availableDetail(currentVersion),
-        buttons: [copy.download, copy.later],
-        defaultId: 0,
-        cancelId: 1,
-        noLink: true,
-      })
-      if (result.response !== 0) {
-        setState('idle', { progress: 0 })
-        return
-      }
-      interactive = true
-      setState('downloading', { progress: 0 })
-      downloadedPath = await downloadImpl({
-        asset: release.asset,
-        downloadsDirectory,
-        fetchImpl,
-        platform,
-        signal: operationController.signal,
-        onProgress: next => setState('downloading', { progress: next }),
-      })
-      setState('downloaded', { progress: 100 })
-      await promptDownloaded()
     } catch (error) {
-      if (!operationController.signal.aborted) await showFailure(error, manual || interactive)
-    } finally {
-      operationController = undefined
+      if (manual) {
+        await showMessage({
+          type: 'error',
+          title: copy.failedTitle,
+          message: copy.failedMessage,
+          detail: errorDetail(error),
+        })
+      }
     }
   }
 
-  function abort() {
-    operationController?.abort()
+  async function download() {
+    if (state !== 'available') return
+    try {
+      await updater.downloadUpdate()
+    } catch (error) {
+      log('error', `Update download failed: ${errorDetail(error)}`)
+    }
+  }
+
+  function restart() {
+    if (state !== 'downloaded') return
+    updater.quitAndInstall()
   }
 
   return {
-    abort,
     check,
+    download,
     initialize: () => supported,
     menuItem,
-    get downloadedPath() { return downloadedPath },
+    restart,
+    get progress() { return progress },
     get state() { return state },
     get supported() { return supported },
+    get version() { return targetVersion },
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,9 @@ import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import process from 'node:process'
-import { app, BrowserWindow, Menu, dialog, ipcMain, net, shell } from 'electron'
-import { createInstallerUpdateController } from './auto-update.js'
+import { app, BrowserWindow, Menu, dialog, ipcMain, shell } from 'electron'
+import { autoUpdater } from 'electron-updater'
+import { createAutoUpdateController } from './auto-update.js'
 import { DSH_RUNTIME_DIRECTORY, readActiveDshRuntime } from './dsh-runtime.js'
 import { createDshUpdateController } from './dsh-update.js'
 import {
@@ -145,26 +146,61 @@ function writeUpdaterLog(level, message) {
   writeLog(level === 'error' ? 'stderr' : 'desktop', `[updater/${level}] ${message}\n`)
 }
 
+function updateSnapshot() {
+  return {
+    state: updateController.state,
+    progress: updateController.progress,
+    version: updateController.version,
+    supported: updateController.supported,
+  }
+}
+
+function broadcastUpdateState() {
+  if (updateController === undefined || mainWindow?.isDestroyed() !== false) return
+  mainWindow.webContents.send('dsh-desktop:update-state', updateSnapshot())
+}
+
+function activateUpdate() {
+  if (updateController === undefined) return
+  if (updateController.state === 'available') return updateController.download()
+  if (updateController.state === 'downloaded') return restartForUpdate()
+  return updateController.check(true)
+}
+
+async function restartForUpdate() {
+  quitting = true
+  restartGeneration += 1
+  pluginOperationController?.abort()
+  defaultPluginInstallController?.abort()
+  dshUpdateController?.abort()
+  clearTimeout(updateCheckTimer)
+  clearTimeout(dshUpdateCheckTimer)
+  await Promise.resolve(server?.stop())
+  logStream?.end()
+  updateController.restart()
+}
+
 function initializeAutoUpdates() {
-  updateController = createInstallerUpdateController({
+  autoUpdater.logger = {
+    info: message => writeUpdaterLog('info', message),
+    warn: message => writeUpdaterLog('warn', message),
+    error: message => writeUpdaterLog('error', message),
+  }
+  updateController = createAutoUpdateController({
     isPackaged: app.isPackaged,
-    platform: process.platform,
-    arch: process.arch,
-    isChinese,
     currentVersion: app.getVersion(),
-    downloadsDirectory: app.getPath('downloads'),
-    fetchImpl: (url, options) => net.fetch(url, options),
+    updater: autoUpdater,
     dialog,
     getWindow: () => mainWindow,
     openReleasePage: url => shell.openExternal(url),
-    openDownloadedFile: path => process.platform === 'linux'
-      ? Promise.resolve(shell.showItemInFolder(path))
-      : shell.openPath(path),
-    onStateChange: buildMenu,
+    onStateChange: () => {
+      buildMenu()
+      broadcastUpdateState()
+    },
     log: writeUpdaterLog,
   })
   if (!updateController.initialize()) {
-    writeUpdaterLog('info', 'No installer is published for this package; the Help menu links to GitHub Releases.')
+    writeUpdaterLog('info', 'Automatic updates are unavailable in this build; the Help menu links to GitHub Releases.')
     return
   }
   updateCheckTimer = setTimeout(() => {
@@ -290,6 +326,16 @@ function installDesktopIpc() {
     activeWorkspace = next.active
     workspaceRoots = next.roots
     if (activeChanged) buildMenu()
+  })
+  ipcMain.handle('dsh-desktop:update-state', (event) => {
+    if (!senderIsHarness(event)) return null
+    return updateSnapshot()
+  })
+  ipcMain.handle('dsh-desktop:update-activate', (event) => {
+    if (!senderIsHarness(event)) return { ok: false, error: 'Untrusted update request' }
+    if (updateController === undefined) return { ok: false, error: 'Updater is unavailable' }
+    void activateUpdate()
+    return { ok: true }
   })
   ipcMain.handle('dsh-desktop:plugins-list', (event) => {
     if (!senderIsPluginManager(event) || dshHome === undefined) return { ok: false, error: 'Untrusted plugin request' }
@@ -816,7 +862,7 @@ function buildMenu() {
         ...(updateItem === undefined ? [] : [{
           label: updateItem.label,
           enabled: updateItem.enabled,
-          click: () => void updateController.check(true),
+          click: () => void activateUpdate(),
         }, { type: 'separator' }]),
         ...(dshUpdateItem === undefined ? [] : [{
           label: dshUpdateItem.label,
@@ -933,7 +979,6 @@ if (!hasLock) {
     restartGeneration += 1
     pluginOperationController?.abort()
     defaultPluginInstallController?.abort()
-    updateController?.abort()
     dshUpdateController?.abort()
     if (updateCheckTimer !== undefined) clearTimeout(updateCheckTimer)
     if (dshUpdateCheckTimer !== undefined) clearTimeout(dshUpdateCheckTimer)

--- a/src/plugins/dsh-desktop-integration/lib/client.js
+++ b/src/plugins/dsh-desktop-integration/lib/client.js
@@ -3,19 +3,26 @@ window.__ModuleLoader__.load({
   factory: (require) => {
     const module = { exports: {} }
     const bridge = globalThis.dshDesktop
+    const React = require('react')
 
     const NS = 'dsh-desktop'
     const STYLE_ID = '@dsh-desktop/integration/actions'
     const WORKSPACE_ACTIONS_MARKER = 'dshDesktopWorkspaceActions'
-    const inject = ['sessions', 'workspaces', 'locale']
+    const inject = ['sessions', 'workspaces', 'locale', 'slots']
     const dictionaries = {
       zh: {
         'open.editor': '用编辑器打开',
         'open.fileManager': '打开文件夹',
+        'update.download': '下载 v{version}',
+        'update.downloading': '下载中 {progress}%',
+        'update.restart': '重启以更新',
       },
       en: {
         'open.editor': 'Open in Editor',
         'open.fileManager': 'Open Folder',
+        'update.download': 'Download v{version}',
+        'update.downloading': 'Downloading {progress}%',
+        'update.restart': 'Restart to Update',
       },
     }
 
@@ -50,6 +57,9 @@ window.__ModuleLoader__.load({
       style.dataset.pluginCss = STYLE_ID
       style.textContent = [
         '.dshDesktopWorkspaceSeparator{height:1px;background:var(--dsw-alias-border-l3);margin:4px 8px}',
+        '.dshDesktopUpdateButton{display:inline-flex;align-items:center;justify-content:center;height:28px;padding:0 12px;flex:none;border:1px solid var(--dsw-alias-border-l3);border-radius:999px;background:transparent;color:var(--dsw-alias-label-secondary);font-size:12px;line-height:1;cursor:pointer}',
+        '.dshDesktopUpdateButton:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover);color:var(--dsw-alias-label-primary)}',
+        '.dshDesktopUpdateButton:disabled{opacity:.55;cursor:default}',
       ].join('')
       document.head.append(style)
       return () => style.remove()
@@ -160,6 +170,61 @@ window.__ModuleLoader__.load({
       }
     }
 
+    function updateButtonLabel(snapshot, t) {
+      if (snapshot.state === 'available') return t('update.download', { version: snapshot.version })
+      if (snapshot.state === 'downloading') return t('update.downloading', { progress: snapshot.progress })
+      return t('update.restart')
+    }
+
+    function createUpdateButton(t) {
+      const { createElement, useEffect, useState } = React
+      return function UpdateButton() {
+        const [snapshot, setSnapshot] = useState(null)
+
+        useEffect(() => {
+          let disposed = false
+          bridge.getUpdateState().then(state => {
+            if (!disposed && state !== null) setSnapshot(state)
+          }).catch(() => {})
+          const unsubscribe = bridge.onUpdateState(state => {
+            if (!disposed && state !== null) setSnapshot(state)
+          })
+          return () => {
+            disposed = true
+            unsubscribe()
+          }
+        }, [])
+
+        if (snapshot === null || snapshot.supported !== true) return null
+        const visible = snapshot.state === 'available'
+          || snapshot.state === 'downloading'
+          || snapshot.state === 'downloaded'
+        if (!visible) return null
+
+        const enabled = snapshot.state !== 'downloading'
+        return createElement('button', {
+          type: 'button',
+          className: 'dshDesktopUpdateButton',
+          disabled: !enabled,
+          onClick: enabled ? () => { void bridge.activateUpdate().catch(() => {}) } : undefined,
+        }, updateButtonLabel(snapshot, t))
+      }
+    }
+
+    function installUpdateButton(ctx, t) {
+      if (typeof bridge?.getUpdateState !== 'function'
+        || typeof bridge?.activateUpdate !== 'function'
+        || typeof bridge?.onUpdateState !== 'function') return () => {}
+
+      const UpdateButton = createUpdateButton(t)
+      const dispose = ctx.slots.inject('conversation.session.header.utilities', () => ctx.slots.register({
+        name: 'conversation.session.header.utilities',
+        id: 'dsh-desktop-update',
+        order: 0,
+      }, UpdateButton))
+      return typeof dispose === 'function' ? dispose : () => {}
+    }
+
     function apply(ctx) {
       if (bridge === undefined
         || typeof bridge.openPath !== 'function'
@@ -170,8 +235,10 @@ window.__ModuleLoader__.load({
 
       ctx.effect(installStyle, 'dsh-desktop: native action styles')
 
-      // Harness exposes a slot for the header utility, but not for children of
-      // the Workspace ellipsis menu. Keep this adapter scoped to that portal.
+      // The header utility slot is the official additive seat; the update
+      // button lands there. The Workspace ellipsis menu has no child slot, so
+      // that adapter keeps its MutationObserver portal below.
+      ctx.effect(() => installUpdateButton(ctx, t), 'dsh-desktop: update button')
       ctx.effect(() => installWorkspaceMenuActions(ctx.workspaces, t), 'dsh-desktop: workspace menu actions')
 
       ctx.effect(() => {

--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -3,4 +3,11 @@ const { contextBridge, ipcRenderer } = require('electron')
 contextBridge.exposeInMainWorld('dshDesktop', Object.freeze({
   openPath: (path, intent = 'auto') => ipcRenderer.invoke('dsh-desktop:open-path', path, intent),
   publishWorkspaceContext: context => ipcRenderer.send('dsh-desktop:workspace-context', context),
+  getUpdateState: () => ipcRenderer.invoke('dsh-desktop:update-state'),
+  activateUpdate: () => ipcRenderer.invoke('dsh-desktop:update-activate'),
+  onUpdateState: callback => {
+    const listener = (_event, state) => callback(state)
+    ipcRenderer.on('dsh-desktop:update-state', listener)
+    return () => ipcRenderer.removeListener('dsh-desktop:update-state', listener)
+  },
 }))

--- a/test/auto-update.test.js
+++ b/test/auto-update.test.js
@@ -1,195 +1,161 @@
 import assert from 'node:assert/strict'
-import { createHash } from 'node:crypto'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import test from 'node:test'
-import {
-  LATEST_RELEASE_API_URL,
-  RELEASES_URL,
-  createInstallerUpdateController,
-  downloadInstallerAsset,
-  installerAssetName,
-  parseLatestRelease,
-  supportsInstallerDownloads,
-} from '../src/auto-update.js'
+import { RELEASES_URL, createAutoUpdateController } from '../src/auto-update.js'
 
-const DIGEST = `sha256:${'a'.repeat(64)}`
-
-function releaseFixture(version = '1.0.0', overrides = {}) {
-  const name = installerAssetName({ version, platform: 'linux', arch: 'x64' })
-  return {
-    tag_name: `v${version}`,
-    draft: false,
-    prerelease: false,
-    assets: [{
-      name,
-      state: 'uploaded',
-      size: 123,
-      digest: DIGEST,
-      browser_download_url: `https://github.com/liguobao/dsh-desktop/releases/download/v${version}/${name}`,
-    }],
-    ...overrides,
-  }
-}
-
-function fixture(overrides = {}) {
+function fixture({ isPackaged = true, update = '1.1.0' } = {}) {
   const messages = []
-  const responses = [...(overrides.responses ?? [])]
-  const openedReleases = []
-  const openedFiles = []
-  const downloads = []
-  const progress = []
-  const release = overrides.release ?? releaseFixture()
-  const controller = createInstallerUpdateController({
-    isPackaged: true,
-    platform: 'linux',
-    arch: 'x64',
-    isChinese: false,
+  const opened = []
+  const logs = []
+  const handlers = {}
+  let quitCalls = 0
+
+  const updater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    on(event, handler) {
+      handlers[event] = handler
+      return this
+    },
+    async checkForUpdates() {
+      handlers['checking-for-update']?.()
+      if (update === null) {
+        handlers['update-not-available']?.({ version: '1.0.0' })
+        return { isUpdateAvailable: false, updateInfo: { version: '1.0.0' } }
+      }
+      handlers['update-available']?.({ version: update })
+      return { isUpdateAvailable: true, updateInfo: { version: update } }
+    },
+    async downloadUpdate() {
+      handlers['download-progress']?.({ percent: 42 })
+      handlers['update-downloaded']?.({ version: update ?? '1.1.0' })
+      return ['/tmp/update.bin']
+    },
+    quitAndInstall() {
+      quitCalls += 1
+    },
+  }
+
+  const controller = createAutoUpdateController({
+    isPackaged,
     currentVersion: '1.0.0',
-    downloadsDirectory: '/Downloads',
-    fetchImpl: overrides.fetchImpl ?? (async url => {
-      assert.equal(url, LATEST_RELEASE_API_URL)
-      return new Response(JSON.stringify(release), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })
-    }),
+    updater,
+    openReleasePage: async url => { opened.push(url) },
     dialog: {
       async showMessageBox(options) {
         messages.push(options)
-        return { response: responses.shift() ?? 1 }
+        return { response: 0 }
       },
     },
     getWindow: () => undefined,
-    openReleasePage: async url => { openedReleases.push(url) },
-    openDownloadedFile: async path => { openedFiles.push(path) },
-    downloadImpl: overrides.downloadImpl ?? (async options => {
-      downloads.push(options)
-      options.onProgress(42)
-      progress.push(42)
-      return `/Downloads/${options.asset.name}`
-    }),
-    log: overrides.log,
-    ...overrides.controller,
+    onStateChange: () => {},
+    log: (level, message) => { logs.push([level, message]) },
   })
-  return { controller, downloads, messages, openedFiles, openedReleases, progress }
+
+  return {
+    controller,
+    handlers,
+    logs,
+    messages,
+    opened,
+    quitCalls: () => quitCalls,
+    updater,
+  }
 }
 
-test('installer assets map to the packages published for each platform and architecture', () => {
-  assert.equal(installerAssetName({ version: '1.2.3', platform: 'darwin', arch: 'arm64' }), 'DSH-Desktop-v1.2.3-macos-arm64.dmg')
-  assert.equal(installerAssetName({ version: '1.2.3', platform: 'darwin', arch: 'x64' }), 'DSH-Desktop-v1.2.3-macos-x64.dmg')
-  assert.equal(installerAssetName({ version: '1.2.3', platform: 'win32', arch: 'x64' }), 'DSH-Desktop-v1.2.3-windows-x64-setup.exe')
-  assert.equal(installerAssetName({ version: '1.2.3', platform: 'linux', arch: 'x64' }), 'DSH-Desktop-v1.2.3-linux-x64.AppImage')
-  assert.equal(supportsInstallerDownloads({ isPackaged: true, platform: 'win32', arch: 'arm64' }), false)
-  assert.equal(supportsInstallerDownloads({ isPackaged: false, platform: 'darwin', arch: 'arm64' }), false)
-})
-test('latest Release parsing requires the exact installer and GitHub SHA-256 metadata', () => {
-  const parsed = parseLatestRelease(releaseFixture('1.2.3'), { platform: 'linux', arch: 'x64' })
-  assert.equal(parsed.version, '1.2.3')
-  assert.equal(parsed.asset.digest, DIGEST)
+test('updater events drive the state machine', () => {
+  const { controller, handlers } = fixture()
 
-  const missingDigest = releaseFixture('1.2.3')
-  missingDigest.assets[0].digest = null
-  assert.throws(() => parseLatestRelease(missingDigest, { platform: 'linux', arch: 'x64' }), /SHA-256/)
+  handlers['checking-for-update']()
+  assert.equal(controller.state, 'checking')
 
-  const untrusted = releaseFixture('1.2.3')
-  untrusted.assets[0].browser_download_url = `https://example.com/${untrusted.assets[0].name}`
-  assert.throws(() => parseLatestRelease(untrusted, { platform: 'linux', arch: 'x64' }), /not trusted/)
+  handlers['update-available']({ version: '1.1.0' })
+  assert.equal(controller.state, 'available')
+  assert.equal(controller.version, '1.1.0')
+
+  handlers['download-progress']({ percent: 42 })
+  assert.equal(controller.state, 'downloading')
+  assert.equal(controller.progress, 42)
+
+  handlers['update-downloaded']({ version: '1.1.0' })
+  assert.equal(controller.state, 'downloaded')
+  assert.equal(controller.progress, 100)
 })
 
-test('unsupported builds open the latest GitHub Release from the menu', async () => {
-  const setup = fixture({ controller: { isPackaged: false } })
-
-  assert.equal(setup.controller.initialize(), false)
-  assert.equal(setup.controller.menuItem().label, 'View Latest Release…')
-  await setup.controller.check(true)
-
-  assert.deepEqual(setup.openedReleases, [RELEASES_URL])
+test('manual control flows are configured on the updater', () => {
+  const { updater } = fixture()
+  assert.equal(updater.autoDownload, false)
+  assert.equal(updater.autoInstallOnAppQuit, true)
 })
 
 test('a manual check reports when the installed version is current', async () => {
-  const setup = fixture()
-  assert.equal(setup.controller.initialize(), true)
+  const { controller, messages } = fixture({ update: null })
 
-  await setup.controller.check(true)
+  await controller.check(true)
 
-  assert.equal(setup.controller.state, 'idle')
-  assert.equal(setup.messages.at(-1).title, 'You’re Up to Date')
-  assert.equal(setup.downloads.length, 0)
+  assert.equal(controller.state, 'idle')
+  assert.equal(messages.at(-1).title, 'You’re Up to Date')
 })
 
-test('an available update downloads the installer and opens the local file after confirmation', async () => {
-  const setup = fixture({ release: releaseFixture('1.1.0'), responses: [0, 0] })
+test('an available update downloads on demand and restarts on demand', async () => {
+  const { controller, quitCalls } = fixture()
 
-  await setup.controller.check(false)
+  await controller.check(false)
+  assert.equal(controller.state, 'available')
+  assert.equal(controller.menuItem().label, 'Download v1.1.0')
 
-  assert.equal(setup.messages[0].title, 'Update Available')
-  assert.equal(setup.messages[1].title, 'Installer Downloaded')
-  assert.equal(setup.downloads.length, 1)
-  assert.equal(setup.downloads[0].asset.name, 'DSH-Desktop-v1.1.0-linux-x64.AppImage')
-  assert.deepEqual(setup.openedFiles, ['/Downloads/DSH-Desktop-v1.1.0-linux-x64.AppImage'])
-  assert.equal(setup.controller.state, 'downloaded')
-  assert.equal(setup.controller.menuItem().label, 'Show Downloaded AppImage…')
+  await controller.download()
+  assert.equal(controller.state, 'downloaded')
+  assert.equal(controller.menuItem().label, 'Restart to Update')
+
+  controller.restart()
+  assert.equal(quitCalls(), 1)
 })
 
-test('background Release check errors are logged without interrupting the user', async () => {
-  const logs = []
-  const setup = fixture({
-    fetchImpl: async () => { throw new Error('offline') },
-    log: (level, message) => logs.push({ level, message }),
-  })
+test('restart is a no-op before the update is downloaded', async () => {
+  const { controller, quitCalls } = fixture()
 
-  await setup.controller.check(false)
+  await controller.check(false)
+  controller.restart()
 
-  assert.equal(setup.controller.state, 'idle')
-  assert.equal(setup.messages.length, 0)
-  assert.match(logs.at(-1).message, /offline/)
+  assert.equal(quitCalls(), 0)
 })
 
-test('installer download streams to a collision-free file and verifies its digest', async (t) => {
-  const directory = mkdtempSync(join(tmpdir(), 'dsh-installer-test-'))
-  t.after(() => rmSync(directory, { recursive: true, force: true }))
-  const data = Buffer.from('verified installer data')
-  const name = 'DSH-Desktop-v1.2.3-macos-arm64.dmg'
-  writeFileSync(join(directory, name), 'existing file')
-  const progress = []
+test('updater errors return to idle and are logged', () => {
+  const { controller, handlers, logs } = fixture()
 
-  const path = await downloadInstallerAsset({
-    asset: {
-      name,
-      size: data.length,
-      digest: `sha256:${createHash('sha256').update(data).digest('hex')}`,
-      url: 'https://github.com/liguobao/dsh-desktop/releases/download/v1.2.3/test.dmg',
-    },
-    downloadsDirectory: directory,
-    fetchImpl: async () => new Response(data),
-    platform: 'darwin',
-    onProgress: value => progress.push(value),
-  })
+  handlers['error'](new Error('network down'))
 
-  assert.equal(path, join(directory, 'DSH-Desktop-v1.2.3-macos-arm64 (1).dmg'))
-  assert.deepEqual(readFileSync(path), data)
-  assert.equal(readFileSync(join(directory, name), 'utf8'), 'existing file')
-  assert.equal(progress.at(-1), 100)
+  assert.equal(controller.state, 'idle')
+  assert.match(logs[0][1], /network down/)
 })
 
-test('installer download removes a file that fails SHA-256 verification', async (t) => {
-  const directory = mkdtempSync(join(tmpdir(), 'dsh-installer-test-'))
-  t.after(() => rmSync(directory, { recursive: true, force: true }))
-  const data = Buffer.from('tampered installer')
+test('unsupported builds open the latest release from a manual check', async () => {
+  const { controller, opened } = fixture({ isPackaged: false })
 
-  await assert.rejects(downloadInstallerAsset({
-    asset: {
-      name: 'DSH-Desktop-v1.2.3-windows-x64-setup.exe',
-      size: data.length,
-      digest: DIGEST,
-      url: 'https://github.com/liguobao/dsh-desktop/releases/download/v1.2.3/test.exe',
-    },
-    downloadsDirectory: directory,
-    fetchImpl: async () => new Response(data),
-    platform: 'win32',
-  }), /SHA-256/)
+  await controller.check(true)
 
-  assert.throws(() => readFileSync(join(directory, 'DSH-Desktop-v1.2.3-windows-x64-setup.exe')), /ENOENT/)
+  assert.equal(controller.state, 'unsupported')
+  assert.deepEqual(opened, [RELEASES_URL])
+  assert.equal(controller.menuItem().label, 'View Latest Release…')
+})
+
+test('the menu item reflects each state', () => {
+  const { controller, handlers } = fixture()
+
+  assert.equal(controller.menuItem().label, 'Check for Updates…')
+
+  handlers['checking-for-update']()
+  assert.equal(controller.menuItem().label, 'Checking for Updates…')
+  assert.equal(controller.menuItem().enabled, false)
+
+  handlers['update-available']({ version: '1.2.0' })
+  assert.equal(controller.menuItem().label, 'Download v1.2.0')
+  assert.equal(controller.menuItem().enabled, true)
+
+  handlers['download-progress']({ percent: 20 })
+  assert.equal(controller.menuItem().label, 'Downloading Update… 20%')
+  assert.equal(controller.menuItem().enabled, false)
+
+  handlers['update-downloaded']({ version: '1.2.0' })
+  assert.equal(controller.menuItem().label, 'Restart to Update')
 })

--- a/test/build-config.test.js
+++ b/test/build-config.test.js
@@ -29,12 +29,16 @@ test('release builds bundle the prebuilt file viewer plugin and its runtime depe
   assert.equal(existsSync(new URL('../node_modules/dsh-file-viewer/cordis.patch.yml', import.meta.url)), true)
 })
 
-test('release builds publish only user-facing installers', () => {
-  assert.equal(packageJson.build.publish, undefined)
-  assert.deepEqual(packageJson.build.mac.target, ['dmg'])
-  assert.match(packageJson.scripts['dist:mac'], /--mac dmg --publish/)
+test('release builds publish GitHub update metadata with a mac zip target', () => {
+  assert.deepEqual(packageJson.build.publish, {
+    provider: 'github',
+    owner: 'liguobao',
+    repo: 'dsh-desktop',
+  })
+  assert.deepEqual(packageJson.build.mac.target, ['dmg', 'zip'])
+  assert.match(packageJson.scripts['dist:mac'], /--mac dmg zip --publish/)
   assert.equal(packageJson.build.mac.artifactName, 'DSH-Desktop-v${version}-macos-${arch}.${ext}')
-  assert.equal(packageJson.dependencies['electron-updater'], undefined)
+  assert.match(packageJson.dependencies['electron-updater'], /^\^?\d+\.\d+\.\d+/)
 })
 
 test('macOS DMG ships the install notes with the copyable quarantine command', () => {

--- a/test/desktop-plugin.test.js
+++ b/test/desktop-plugin.test.js
@@ -35,7 +35,9 @@ test('client adapter exposes native actions without spawning local processes', (
   assert.match(source, /workspaces\.openPath = openPath/)
   assert.match(source, /bridge\.openPath\(path, 'auto'\)/)
   assert.match(source, /bridge\.publishWorkspaceContext/)
-  assert.doesNotMatch(source, /conversation\.session\.header\.utilities/)
+  assert.match(source, /conversation\.session\.header\.utilities/)
+  assert.match(source, /require\('react'\)/)
+  assert.match(source, /dsh-desktop-update/)
   assert.doesNotMatch(source, /dsh-desktop-workspace-editor/)
   assert.match(source, /installWorkspaceMenuActions/)
   assert.match(source, /'editor', pendingPath, 'editor'/)
@@ -72,10 +74,11 @@ test('client adapter replaces and restores the Harness path action at runtime', 
     window: { __ModuleLoader__: { load: value => { registration = value } } },
   })
   vm.runInContext(source, context)
-
-  assert.equal(registration.id, '@dsh-desktop/integration')
-  const plugin = registration.factory(() => assert.fail('client adapter should not require UI modules'))
-  assert.deepEqual(Array.from(plugin.inject), ['sessions', 'workspaces', 'locale'])
+  const plugin = registration.factory(name => {
+    if (name === 'react') return {}
+    assert.fail(`client adapter should not require ${name}`)
+  })
+  assert.deepEqual(Array.from(plugin.inject), ['sessions', 'workspaces', 'locale', 'slots'])
 
   const subscribers = []
   const originalOpenPath = async () => { throw new Error('unexpected fallback') }


### PR DESCRIPTION
## Summary

Replaces the manual installer downloader with `electron-updater` so the app can download, apply, and restart into new releases in place — the VS Code-style flow. The update surfaces as a button in the Harness conversation-header utilities slot (the official additive seat), so no Harness DOM is patched.

## Changes

- **`src/auto-update.js`** — rewritten around an electron-updater-driven state machine (`idle → checking → available → downloading → downloaded`). The updater is dependency-injected so the controller stays testable under plain Node.
- **`src/main.js`** — wires `autoUpdater`, exposes update state over IPC, and adds a `restartForUpdate` path that stops the harness before `quitAndInstall()` (avoids the `before-quit` `preventDefault` interfering with install).
- **`src/plugins/dsh-desktop-integration/lib/client.js`** — mounts the update button in `conversation.session.header.utilities` via `slots.inject`, with zh/en i18n and theme-token CSS. The button only appears when an update is available.
- **`src/preload.cjs`** — extends the `dshDesktop` bridge with `getUpdateState` / `activateUpdate` / `onUpdateState`.
- **`package.json`** — adds `electron-updater`, a GitHub `publish` provider (`liguobao/dsh-desktop`), and a mac `zip` target (required for Squirrel.Mac updates).
- **`.github/workflows/build.yml`** — uploads `latest*.yml` metadata and the mac zip alongside the installers.

## Verification

- `npm run check` passes.
- `npm test`: 80/81 pass. The one failure (`detects supported editors from PATH`) is pre-existing on this machine (local Cursor/Zed installs), unrelated to this change.
- `electron-updater` instantiates correctly in a real Electron runtime (`MacUpdater`).

## Notes for maintainers

- End-to-end (download → restart → new version) can only be exercised by a signed, packaged build against a tagged GitHub Release with `latest*.yml` present — i.e. after this merges and a `v*` tag is pushed. macOS auto-update requires the Developer ID signing/notarization now on `master`.
