### PR TITLE
fix(windows): prevent managed PowerShell console windows

### DIFF
--- a/docs/bugs/windows-pwsh-original-analysis.md
+++ b/docs/bugs/windows-pwsh-original-analysis.md
@@ -1,0 +1,230 @@
+# Bug 分析报告：pwsh 工具弹出终端窗口问题
+
+> 历史原始方案，仅供了解调查背景，不能直接应用。第 4.3 节的 `1108` / `CREATE_NO_WINDOW (80)` 为错误值；“后台不会弹窗”和低风险保证也尚未成立。已验证的根因、实际补丁与测试结果见 [后续调查报告](windows-pwsh-root-cause-review.md)。下文保留原始记录。
+
+## 一、问题描述
+
+**现象**：当通过 DSH 调用 `pwsh` 工具执行 PowerShell 命令时，每次都会弹出一个 PowerShell 终端窗口，干扰用户操作。
+
+**预期行为**：后台静默执行，不弹出可见窗口。
+
+**实际行为**：前台调用弹出窗口，只有使用 `run_in_background: true` 才能避免弹窗。
+
+---
+
+## 二、影响范围
+
+- **平台**：Windows
+- **模块**：`@deepseek-ai/dsh-win32-process`
+- **触发场景**：所有通过 `pwsh` 工具执行的前台 PowerShell 命令
+
+---
+
+## 三、根因分析
+
+### 3.1 调用链路
+
+```
+dsh-tool-pwsh (工具层)
+  └─→ dsh-pwsh-local (执行器)
+       └─→ ctx.subprocess.spawn() (子进程服务)
+            └─→ dsh-subprocess-local (本地实现)
+                 └─→ launchWindowsJob() (Windows Job 启动)
+                      └─→ spawnJobProcess() (核心创建函数)
+                           └─→ spawnCurrentTokenJobProcess()
+                                └─→ CreateProcessW() (Win32 API)
+```
+
+### 3.2 问题根源
+
+在 `dsh-win32-process/lib/index.js` 中，`spawnJobProcess()` 函数通过 Win32 API `CreateProcessW` 创建子进程，但 **STARTUPINFOW 结构体配置不完整**：
+
+**当前代码**（第 534-540 行）：
+```javascript
+encodeStartupInfo(startupInfo, {
+    cb: 104,
+    dwFlags: 256,  // 只有 STARTF_USESTDHANDLES
+    hStdInput: stdio.stdin,
+    hStdOutput: stdio.stdout,
+    hStdError: stdio.stderr
+});
+```
+
+**当前调用**（第 615 行）：
+```javascript
+api.createProcessW(
+    options.applicationName,
+    commandLine,
+    null, null,
+    1,                    // bInheritHandles
+    1028,                 // dwCreationFlags = CREATE_UNICODE_ENVIRONMENT(1024) + CREATE_SUSPENDED(4)
+    environment,
+    options.cwd,
+    startupInfo,
+    processInfo
+);
+```
+
+### 3.3 缺失的配置
+
+| 常量 | 值 | 作用 | 当前状态 |
+|---|---|---|---|
+| `STARTF_USESHOWWINDOW` | `0x00000001` (1) | 启用 `wShowWindow` 字段 | ❌ 未设置 |
+| `SW_HIDE` | `0x00000000` (0) | 隐藏窗口 | ❌ 未设置 |
+| `CREATE_NO_WINDOW` | `0x08000000` (134217728) | 不创建窗口 | ❌ 未设置 |
+
+### 3.4 导致结果
+
+由于未设置 `STARTF_USESHOWWINDOW` 标志，`CreateProcessW` 忽略 `wShowWindow` 字段，使用默认值 `SW_SHOW`，导致 PowerShell 打开一个可见的控制台窗口。
+
+---
+
+## 四、修复方案
+
+### 4.1 修改文件
+
+**路径**：`C:\Program Files\DSH Desktop\resources\app\node_modules\@deepseek-ai\dsh-win32-process\lib\index.js`
+
+### 4.2 修改点 1：启动信息配置
+
+**位置**：第 534-540 行
+
+```javascript
+// 修改前
+encodeStartupInfo(startupInfo, {
+    cb: 104,
+    dwFlags: 256,
+    hStdInput: stdio.stdin,
+    hStdOutput: stdio.stdout,
+    hStdError: stdio.stderr
+});
+
+// 修改后
+encodeStartupInfo(startupInfo, {
+    cb: 104,
+    dwFlags: 257,       // 256 + 1: STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW
+    wShowWindow: 0,     // SW_HIDE: 隐藏窗口
+    hStdInput: stdio.stdin,
+    hStdOutput: stdio.stdout,
+    hStdError: stdio.stderr
+});
+```
+
+### 4.3 修改点 2：创建标志
+
+**位置**：第 615 行
+
+```javascript
+// 修改前
+return spawnJobProcess(api, options, () => targetCarrierHandles(api, options.stdio), "CreateProcessW", (startupInfo, processInfo) => api.createProcessW(options.applicationName, commandLine, null, null, 1, 1028, environment, options.cwd, startupInfo, processInfo));
+
+// 修改后
+return spawnJobProcess(api, options, () => targetCarrierHandles(api, options.stdio), "CreateProcessW", (startupInfo, processInfo) => api.createProcessW(options.applicationName, commandLine, null, null, 1, 1108, environment, options.cwd, startupInfo, processInfo));
+```
+
+**数值变化**：
+- `1028` = `CREATE_UNICODE_ENVIRONMENT (1024)` + `CREATE_SUSPENDED (4)`
+- `1108` = `1028` + `CREATE_NO_WINDOW (80)`
+
+### 4.4 STARTUPINFOW 结构体定义
+
+确认结构体已包含 `wShowWindow` 字段（第 48 行），当前已有定义：
+
+```javascript
+const STARTUPINFOW = koffi.struct("DSH_STARTUPINFOW", {
+    cb: "uint32",
+    lpReserved: "str16",
+    lpDesktop: "str16",
+    lpTitle: "str16",
+    dwX: "uint32",
+    dwY: "uint32",
+    dwXSize: "uint32",
+    dwYSize: "uint32",
+    dwXCountChars: "uint32",
+    dwYCountChars: "uint32",
+    dwFillAttribute: "uint32",
+    dwFlags: "uint32",
+    wShowWindow: "uint16",    // ✅ 已存在
+    cbReserved2: "uint16",
+    lpReserved2: koffi.pointer("uint8"),
+    hStdInput: PVOID,
+    hStdOutput: PVOID,
+    hStdError: PVOID
+});
+```
+
+---
+
+## 五、验证方法
+
+### 5.1 修改后测试步骤
+
+1. **重启 DSH Desktop**（关闭并重新打开）
+2. **执行前台 pwsh 调用**：
+   ```json
+   {
+     "command": "Write-Host '测试 - $(Get-Date -Format \"HH:mm:ss\")'",
+     "description": "验证窗口隐藏"
+   }
+   ```
+3. **观察结果**：不应弹出 PowerShell 窗口
+
+### 5.2 对比测试
+
+| 测试项 | 修改前 | 修改后（预期） |
+|---|---|---|
+| 前台 pwsh 调用 | 弹出窗口 | 静默执行 |
+| 后台 pwsh 调用 | 静默执行 | 静默执行（不变） |
+| 输出捕获 | ✅ 正常 | ✅ 正常 |
+| 退出码返回 | ✅ 正常 | ✅ 正常 |
+
+---
+
+## 六、风险评估
+
+### 6.1 低风险影响
+
+- ✅ 仅影响 Windows 平台的子进程创建
+- ✅ 不改变进程管理机制（Job Object 仍正常工作）
+- ✅ 不影响 stdin/stdout/stderr 的管道重定向
+- ✅ 后台任务行为不受影响
+
+### 6.2 注意事项
+
+- ⚠️ 需要管理员权限修改系统文件
+- ⚠️ DSH 更新后会覆盖修改，需重新应用
+- ⚠️ 如果将来需要调试前台命令，可能需要临时移除修改
+
+---
+
+## 七、备选方案
+
+### 7.1 临时规避（当前可用）
+
+对于长时间运行的命令，使用 `run_in_background: true` 参数：
+
+```json
+{
+  "command": "你的命令",
+  "description": "后台运行",
+  "run_in_background": true
+}
+```
+
+### 7.2 上游修复建议
+
+建议向 `@deepseek-ai/dsh-win32-process` 维护者提交 PR，将此修复纳入正式版本。
+
+---
+
+## 八、参考链接
+
+- [Win32 STARTUPINFOW 结构体文档](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow)
+- [Win32 CREATEPROCESS 标志](https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags)
+- DSH 源码位置：`C:\Program Files\DSH Desktop\resources\app\node_modules\@deepseek-ai\dsh-win32-process\`
+
+---
+
+**报告生成时间**：2025年9月11日
+**报告作者**：AI Assistant (Agnes)
+**审核状态**：待人工审核

--- a/docs/bugs/windows-pwsh-root-cause-review.md
+++ b/docs/bugs/windows-pwsh-root-cause-review.md
@@ -1,0 +1,77 @@
+# PowerShell 控制台弹窗：根因、修复与验证
+
+## 结论
+
+在无控制台的 Electron run-as-node 进程中，普通 Windows Job 路径通过 `CreateProcessW(..., 1028, ...)` 启动 PowerShell，会创建可见控制台。仅隐藏 Harness 父进程不能让后续原生进程创建自动继承同一策略。
+
+本次针对桌面 `0.1.56`（调查基线 `a2ec500`）锁定的 `@deepseek-ai/*@0.1.5-rc.1` 依赖生成两个 patch-package 补丁。没有修改 Program Files 中的安装文件。
+
+## 代码依据
+
+| 层级 | 文件 / 函数 | 事实 |
+| --- | --- | --- |
+| 桌面启动 | `src/main.js` | 使用 process.execPath 和 ELECTRON_RUN_AS_NODE=1 |
+| Harness 启动 | `src/harness-server.js` | 已有 windowsHide: true、shell: false、管道 stdio |
+| 工具前后台 | `dsh-tool-pwsh/lib/index.js` | 前台调用 shell.run，后台通过 jobs 调用 shell.start |
+| 执行器 | `dsh-pwsh-local/lib/index.js` | runArgv 和 startArgv 都调用 ctx.subprocess.spawn，没有按前后台选择隐藏窗口的分支 |
+| runner 创建 | `dsh-subprocess-local/lib/index.js` 的 launchWindowsJob | Node spawn 启动独立 runner，原来没有 windowsHide |
+| 目标创建 | `dsh-subprocess-local/lib/runner.js` | 使用 fd 4/5/6 的 stdio carrier 调用 spawnCurrentTokenJobProcess |
+| 原生创建 | `dsh-win32-process/lib/index.js` | 原创建标志仅为 CREATE_UNICODE_ENVIRONMENT 和 CREATE_SUSPENDED |
+
+最初依据来自版本匹配的本机安装依赖；随后在本仓库 npm ci 获取的依赖上完成真实 runner 回归。原报告声称“只有前台弹窗，后台不弹窗”，尚未解释或复现这种差异，不能将后台模式视为可靠规避方案。
+
+## 隔离实验与修复选择
+
+先前隔离实验以无控制台的 Electron 启动已安装的 Win32 helper，仅在实验进程内替换 API 参数，PowerShell 通过 GetConsoleWindow 和 IsWindowVisible 读取状态：
+
+| 配置 | 控制台存在 | 控制台可见 | 中文 stdout / stderr | 退出码 | 正常退出后 Job 已空 |
+| --- | --- | --- | --- | --- | --- |
+| 原始 1028 | 是 | 是 | 正常 | 7 | 是 |
+| STARTF_USESHOWWINDOW + SW_HIDE | 是 | 否 | 正常 | 7 | 是 |
+| 添加 CREATE_NO_WINDOW | 否 | 否 | 正常 | 7 | 是 |
+
+两种方式都消除该实验中的可见控制台，但 SW_HIDE 保留控制台，CREATE_NO_WINDOW 改变控制台关联。本补丁选择后者，避免在共享 STARTUPINFO 中设置 SW_HIDE 而改变 GUI 程序初始显示行为。CREATE_NO_WINDOW 对非控制台程序会被忽略。
+
+正确值是 `1028 | 0x08000000 = 134218756`（0x08000404）。原始方案的 `1108` 是 0x454，额外启用了 CREATE_NEW_CONSOLE 和 IDLE_PRIORITY_CLASS，不能用于修复。
+
+## 实际改动
+
+- `patches/@deepseek-ai+dsh-win32-process+0.1.5-rc.1.patch`：只在普通令牌 Job 创建点增加 CREATE_NO_WINDOW，保留 Unicode 环境、挂起创建、句柄继承、Job 绑定和 ResumeThread。
+- `patches/@deepseek-ai+dsh-subprocess-local+0.1.5-rc.1.patch`：runner 的 Node spawn 增加 windowsHide: true。这是显式后台启动策略；未将 runner 独立弹窗认定为已验证的第二个根因。
+- `test/windows-subprocess.test.js` 和 `scripts/fixtures/windows-subprocess-probe.cjs`：在真实捆绑 Electron 下运行 LocalSubprocessRuntime，经过实际 runner、Win32 API 和管道，不替换成模拟子进程。
+
+不改共享 STARTUPINFO、受限令牌函数、ConPTY 或桌面用户主动打开应用的路径。普通 Job 控制台命令会失去控制台关联，依赖控制台 API 的其他程序仍需兼容性评估。
+
+仓库已有 postinstall: patch-package，npm ci 时自动应用补丁。上游修复对应 packages/subprocess/win32-process 和 packages/subprocess/subprocess-local；升级到包含等效修复的版本时应移除补丁。
+
+## 回归验证
+
+新测试使用完整 Electron / PowerShell 路径，环境 PATH 仅含 System32，不依赖用户安装的 node/npm/pnpm。测试 Windows PowerShell 5.1，以及机器安装在 Program Files 标准路径的 PowerShell 7（如果存在）。
+
+测试断言包括：
+
+- Electron 父进程没有控制台，PowerShell 目标也没有控制台。
+- runner 使用 process.execPath、ELECTRON_RUN_AS_NODE=1、windowsHide: true 和最小 PATH。
+- stdin 标记、中文 stdout、stderr、退出码 7、带空格工作目录和环境变量正确。
+- AbortSignal 能终止长任务并完成 waitForExit。
+
+在添加生产补丁前，回归测试明确失败于“PowerShell must not allocate a console”；添加补丁后通过。最初隔离实验只覆盖文件句柄；本回归进一步覆盖真实 runner 与管道。
+
+验证命令：
+
+```sh
+npm ci --no-audit --no-fund
+node --test test/windows-subprocess.test.js
+npm test
+npm run check
+```
+
+本机最终结果：干净 npm ci 成功应用两个补丁；npm test 为 97/97 通过；npm run check 及新增脚本的 node --check 均通过。本机仓库回归使用 Windows PowerShell 5.1；前述隔离对比另覆盖 PowerShell 7。其他平台由 PR 的构建矩阵继续验证。
+
+尚需发布验收：从 Explorer 启动最终安装包并观察前后台命令是否瞬间闪窗、抢焦点；真实 UI job_kill、子孙进程清理、大输出、沙箱、PTY、GUI 命令和跨平台回归。当前自动化覆盖普通 Job 路径，未模拟完整模型工具会话。
+
+## 参考
+
+- [原始方案（历史记录，含已指出的错误）](windows-pwsh-original-analysis.md)
+- [Microsoft：Process Creation Flags](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags)
+- [Microsoft：STARTUPINFOW](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow)

--- a/patches/@deepseek-ai+dsh-subprocess-local+0.1.5-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-subprocess-local+0.1.5-rc.1.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js b/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js
+index 8e1b9f9..2c6382b 100644
+--- a/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js
+@@ -503,6 +503,7 @@ function launchWindowsJob(spec, targetEnv, internals = {}) {
+ 		], {
+ 			cwd: process.cwd(),
+ 			env: runnerEnvironment(WINDOWS_RUNNER_SELECTION, invocation),
++			windowsHide: true,
+ 			stdio: runnerStdio(spec, true, ignoredStdinFd ?? "pipe")
+ 		});
+ 	} finally {

--- a/patches/@deepseek-ai+dsh-win32-process+0.1.5-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-win32-process+0.1.5-rc.1.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@deepseek-ai/dsh-win32-process/lib/index.js b/node_modules/@deepseek-ai/dsh-win32-process/lib/index.js
+index 697e5e4..dd6e77a 100644
+--- a/node_modules/@deepseek-ai/dsh-win32-process/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-win32-process/lib/index.js
+@@ -612,7 +612,10 @@ function spawnInheritedJobProcess(api, options) {
+ function spawnCurrentTokenJobProcess(api, options) {
+ 	const commandLine = buildCommandLine(options.command, options.args);
+ 	const environment = encodeWindowsEnvironment(options.env);
+-	return spawnJobProcess(api, options, () => targetCarrierHandles(api, options.stdio), "CreateProcessW", (startupInfo, processInfo) => api.createProcessW(options.applicationName, commandLine, null, null, 1, 1028, environment, options.cwd, startupInfo, processInfo));
++	// Ordinary managed commands use redirected stdio, not a console window.
++	const CREATE_NO_WINDOW = 0x08000000;
++	const creationFlags = 1028 | CREATE_NO_WINDOW;
++	return spawnJobProcess(api, options, () => targetCarrierHandles(api, options.stdio), "CreateProcessW", (startupInfo, processInfo) => api.createProcessW(options.applicationName, commandLine, null, null, 1, creationFlags, environment, options.cwd, startupInfo, processInfo));
+ }
+ /**
+ * Verify that an unnamed kill-on-close Job can be created and released now.

--- a/scripts/fixtures/windows-subprocess-probe.cjs
+++ b/scripts/fixtures/windows-subprocess-probe.cjs
@@ -1,0 +1,76 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const childProcess = require('node:child_process')
+const { syncBuiltinESMExports } = require('node:module')
+const koffi = require('koffi')
+
+// Observe the real runner invocation; never substitute a mock process.
+const invocations = []
+const originalSpawn = childProcess.spawn
+childProcess.spawn = (...args) => {
+  invocations.push(args)
+  return originalSpawn(...args)
+}
+syncBuiltinESMExports()
+
+async function main() {
+  const { Context } = await import('@deepseek-ai/cordis')
+  const { LocalSubprocessRuntime } = await import('@deepseek-ai/dsh-subprocess-local')
+  const getConsoleWindow = koffi.load('kernel32.dll').func('void *GetConsoleWindow()')
+  assert.equal(getConsoleWindow(), null, 'Electron host must have no console')
+  const ctx = new Context()
+  const runtime = new LocalSubprocessRuntime(ctx)
+  const makeSpec = command => ({
+    argv: [process.argv[2], '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command],
+    cwd: process.cwd(),
+    env: { DSH_CONSOLE_TEST: 'env-marker' },
+    stdio: { stdin: { data: 'stdin-marker\n' }, stdout: { maxBytes: 65536 }, stderr: { maxBytes: 65536 } },
+    graceMs: 100,
+  })
+  try {
+    const command = `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class ConsoleProbe { [DllImport("kernel32.dll")] public static extern IntPtr GetConsoleWindow(); }'; @{ hasConsole = ([ConsoleProbe]::GetConsoleWindow() -ne [IntPtr]::Zero); text = '中文输出'; input = [Console]::In.ReadLine(); cwd = (Get-Location).Path; env = $env:DSH_CONSOLE_TEST } | ConvertTo-Json -Compress; [Console]::Error.WriteLine('stderr-marker'); exit 7`
+    const proc = runtime.spawn(makeSpec(command))
+    const outcome = await proc.done
+    await proc.waitForExit()
+    const output = JSON.parse(proc.collected.stdout.readFrom(0).text)
+    assert.equal(output.hasConsole, false, 'PowerShell must not allocate a console')
+    assert.equal(output.text, '中文输出')
+    assert.equal(output.input, 'stdin-marker')
+    assert.equal(output.cwd.toLowerCase(), process.cwd().toLowerCase())
+    assert.equal(output.env, 'env-marker')
+    assert.equal(proc.collected.stderr.readFrom(0).text.trim(), 'stderr-marker')
+    assert.equal(outcome.exitCode, 7)
+
+    const controller = new AbortController()
+    const longRunning = runtime.spawn({ ...makeSpec("[Console]::Out.WriteLine('ready'); Start-Sleep -Seconds 60"), signal: controller.signal })
+    const deadline = Date.now() + 15_000
+    while (!longRunning.collected.stdout.readFrom(0).text.includes('ready')) {
+      assert.ok(Date.now() < deadline, 'Long-running command did not become ready')
+      await new Promise(resolve => setTimeout(resolve, 25))
+    }
+    controller.abort()
+    const stopped = await longRunning.done
+    await longRunning.waitForExit()
+    assert.equal(stopped.exitCode, 1)
+
+    assert.equal(invocations.length, 2, 'Both commands must use the managed runner')
+    for (const [exe, args, options] of invocations) {
+      assert.equal(exe, process.execPath, 'Use bundled Electron, never a PATH node/npm/pnpm')
+      assert.match(args[0], /runner\.js$/)
+      assert.equal(options.env.ELECTRON_RUN_AS_NODE, '1')
+      assert.equal(options.env.PATH, process.env.PATH)
+      assert.equal(options.windowsHide, true)
+      assert.equal(options.shell ?? false, false)
+    }
+    console.log('windowless PowerShell and cancellation verified')
+  } finally {
+    await runtime.disposeManagedProcesses()
+    await ctx.fiber.dispose()
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/test/windows-subprocess.test.js
+++ b/test/windows-subprocess.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const require = createRequire(import.meta.url)
+const fixture = fileURLToPath(new URL('../scripts/fixtures/windows-subprocess-probe.cjs', import.meta.url))
+
+test('Windows managed PowerShell stays windowless under bundled Electron with a GUI-style PATH', {
+  skip: process.platform !== 'win32',
+  timeout: 120_000,
+}, () => {
+  const electron = require('electron')
+  const shells = [
+    join(process.env.SystemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    join(process.env.ProgramFiles, 'PowerShell', '7', 'pwsh.exe'),
+  ].filter(existsSync)
+  assert.ok(shells.length > 0, 'A Windows PowerShell installation is required')
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh console regression '))
+  try {
+    for (const shell of shells) {
+      const result = spawnSync(electron, [fixture, shell], {
+        cwd,
+        shell: false,
+        windowsHide: true,
+        encoding: 'utf8',
+        timeout: 50_000,
+        env: {
+          SystemRoot: process.env.SystemRoot,
+          WINDIR: process.env.SystemRoot,
+          TEMP: cwd,
+          TMP: cwd,
+          PATH: join(process.env.SystemRoot, 'System32'),
+          ELECTRON_RUN_AS_NODE: '1',
+        },
+      })
+      assert.equal(result.error, undefined)
+      assert.equal(result.status, 0, `${shell}\n${result.stderr}\n${result.stdout}`)
+      assert.match(result.stdout, /windowless PowerShell and cancellation verified/)
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 问题与修复

当 Electron 在无控制台环境下运行时，普通的 Windows Job 路径会使用 `CreateProcessW` 启动 PowerShell，并设置 flags 为 `1028`，这会导致工具命令执行时可能出现一个可见的控制台窗口。隐藏 Harness 父进程并不能隐藏后续由原生方式创建出来的这个子进程窗口。

本 PR 利用现有的 `patch-package` postinstall 机制进行了修复：

* 在普通的、使用当前 token 创建目标进程的位置加入 `CREATE_NO_WINDOW`；
* 为私有 runner 增加 `windowsHide: true`。

该修改仍然保留：

* 挂起状态创建进程；
* Unicode 环境变量处理；
* stdio 继承；
* Job 生命周期管理。

同时不会修改共享的 `STARTUPINFO`，也不会影响 restricted-token 或 PTY 相关路径。

## 验证

* 在未打补丁的依赖环境中，回归测试会失败，因为 PowerShell 会分配控制台窗口；应用补丁后测试通过。
* 执行干净安装 `npm ci --no-audit --no-fund`：两个带版本号的补丁均成功应用。
* Windows 环境下执行 `npm test`：**97 个测试通过，0 个失败**。
* `npm run check` 以及新增测试/helper 的语法检查均通过。
* 测试覆盖了真实调用链：

  `打包后的 Electron → DSH runner → PowerShell`

  并使用仅包含 System32 的最小化 `PATH`。

测试检查内容包括：

* 不出现控制台窗口；
* 正确选择打包后的运行时；
* stdin/stdout/stderr 工作正常；
* 中文输出正常；
* 正确返回退出码 `7`；
* cwd 和环境变量正确；
* 在检测到 readiness marker 后能够正常执行取消操作。

本地已测试 Windows PowerShell 5.1；如果 PowerShell 7 安装在标准的 Program Files 路径下，测试也会覆盖 PowerShell 7。

## 调查说明

两份中文调查文档已经包含在 `docs/bugs/` 目录中。

最初的方案已经被明确标记为历史方案：其中提出的 `1108` flags 数值是错误的；正确的组合 flags 为：

`134218756`（`0x08000404`）

后续调查报告中包含了相关证据、影响范围以及仍需进行的验证工作。

最初报告中提到的“前台运行与后台运行存在差异”这一现象，目前尚未被独立复现。

以下内容仍需要维护者或 CI 环境进一步验证：

* 最终打包应用的 UI 表现，包括短暂闪窗和焦点抢占；
* restricted-token / PTY 行为；
* 子孙进程清理；
* 其他平台的构建情况。

需要注意的是，`CREATE_NO_WINDOW` 会改变普通受管理控制台程序与控制台之间的关联方式，因此，对于依赖 Windows Console API 的调用方，仍需要进行兼容性审查。


## Problem and fix

When Electron runs without a console, the ordinary Windows Job path starts PowerShell with `CreateProcessW` flags `1028`, allowing a visible console to appear for tool commands. Hiding the Harness parent does not hide this subsequent native process creation.

This PR uses the existing `patch-package` postinstall to add `CREATE_NO_WINDOW` at the ordinary current-token target creation point and `windowsHide: true` for the private runner. It preserves suspended creation, Unicode environment handling, stdio inheritance, and Job lifecycle; it does not alter shared STARTUPINFO or the restricted-token/PTY paths.

## Validation

- A regression test failed on unpatched dependencies because PowerShell allocated a console, then passed with the patches.
- Clean `npm ci --no-audit --no-fund`: both versioned patches applied successfully.
- `npm test`: **97 passed, 0 failed** on Windows.
- `npm run check` and syntax checks for the new test/helper passed.
- The test exercises real bundled Electron → DSH runner → PowerShell with a minimal System32-only PATH. It checks no console, bundled runtime selection, stdin/stdout/stderr, Chinese output, exit code 7, cwd/env, and cancellation after a readiness marker. Windows PowerShell 5.1 was tested locally; the test also exercises PowerShell 7 when installed in its standard Program Files location.

## Investigation notes

The two Chinese investigation documents are included in `docs/bugs/`. The original proposal is clearly marked historical: its proposed `1108` value is incorrect; the correct combined flags are `134218756` (`0x08000404`). The follow-up report contains evidence, scope, and remaining verification. The initially reported foreground/background difference has not been independently reproduced.

Final packaged-app UI checks (transient flashing/focus), restricted-token/PTY behavior, descendant cleanup, and other-platform builds remain for maintainer/CI verification. `CREATE_NO_WINDOW` changes console association for ordinary managed console programs, so console-API-dependent callers deserve compatibility review.