### PR TITLE
fix(windows): prevent sandboxed PowerShell console windows

### DIFF
--- a/docs/bugs/windows-pwsh-sandbox-console-window.md
+++ b/docs/bugs/windows-pwsh-sandbox-console-window.md
@@ -1,0 +1,192 @@
+# PowerShell 沙箱控制台弹窗：根因分析与修复报告
+
+## 结论
+
+DSH Desktop 0.1.56 在 Windows 的“仅查看”和“工作区修改”权限下通过 `pwsh` 工具执行命令时，实际调用的是受限令牌 ACL 沙箱路径，而不是普通进程创建路径：
+
+```text
+dsh-tool-pwsh
+  -> dsh-pwsh-sandbox
+  -> dsh-sandbox-local / windows-acl
+  -> AclSandbox.spawn({ stdio: "inherit" })
+  -> spawnSandboxedInherited
+  -> spawnInheritedJobProcess
+  -> CreateProcessAsUserW(..., creationFlags = 4, ...)
+```
+
+`4` 仅为 `CREATE_SUSPENDED`。该路径没有设置 `CREATE_NO_WINDOW`，并且使用继承的标准输入输出启动控制台程序，因此在无控制台的 Electron / Harness 进程中会让 Windows 为 PowerShell 创建一个可见控制台窗口。
+
+修复只针对受限令牌沙箱路径，将创建标志改为：
+
+```js
+const CREATE_NO_WINDOW = 0x08000000;
+
+createRestrictedProcess(
+  api,
+  options,
+  commandLine,
+  4 | CREATE_NO_WINDOW,
+  startupInfo,
+  processInfo,
+);
+```
+
+## 问题现象与影响范围
+
+- **平台**：Windows。
+- **权限模式**：`read-only`（仅查看）和 `workspace-write`（工作区修改）。
+- **触发方式**：通过 DSH 的 `pwsh` 工具执行 PowerShell 命令。
+- **表现**：执行期间弹出可见的 PowerShell 终端窗口。
+- **对比**：切换为“完全权限”后不弹出窗口，因此问题并非所有 `pwsh` 调用共有，而是与受限权限路径有关。
+- **安全边界**：修复只影响窗口显示，不应削弱 ACL、受限令牌、Job Object 或文件权限限制。
+
+## 实际调用链与根因
+
+### 受限权限路径
+
+在 `@deepseek-ai/dsh-sandbox-windows-acl` 中，`stdio: "inherit"` 的沙箱调用最终进入 `spawnSandboxedInherited`，再由 `@deepseek-ai/dsh-win32-process` 的 `spawnInheritedJobProcess` 创建进程。
+
+原实现为：
+
+```js
+return spawnJobProcess(
+  api,
+  options,
+  () => inheritedStandardHandles(api),
+  "CreateProcessAsUserW",
+  (startupInfo, processInfo) =>
+    createRestrictedProcess(api, options, commandLine, 4, startupInfo, processInfo),
+);
+```
+
+这里使用 `CreateProcessAsUserW` 创建受限令牌进程，缺失 `CREATE_NO_WINDOW`。在宿主进程没有控制台的情况下，Windows 为这个控制台程序创建可见控制台，因此出现弹窗。
+
+### 为什么完全权限不弹窗
+
+“完全权限”走的是另一条路径：
+
+```text
+spawnCurrentTokenJobProcess
+  -> CreateProcessW(..., 1028, ...)
+```
+
+该路径使用 fd carrier 的重定向 stdio，而不是 ACL 沙箱的继承 stdio；它也不会进入 `spawnInheritedJobProcess`。因此，修改普通 `CreateProcessW` 路径并不能修复仅查看和工作区修改模式下的弹窗。
+
+### 上一轮定位为什么无效
+
+上一轮修复做了两件事：
+
+1. 在 `spawnCurrentTokenJobProcess` 的普通 `CreateProcessW` 调用上增加 `CREATE_NO_WINDOW`。
+2. 在 `dsh-subprocess-local` 的 runner `spawn()` 上增加 `windowsHide: true`。
+
+这两处都不是实际弹窗路径：
+
+- 沙箱权限模式下启动 PowerShell 的是 runner 内部的 `CreateProcessAsUserW`，不经过普通 `spawnCurrentTokenJobProcess`。
+- Node `spawn()` 的 `windowsHide` 只作用于 runner 进程本身，不会传递到 runner 后续调用的原生 Win32 API。
+- 因此安装版虽然在普通路径和 runner 启动处发生了改动，但沙箱路径仍然是 `4`，弹窗问题依旧存在。
+
+## 修复方案
+
+### 选定的实现
+
+在 `@deepseek-ai/dsh-win32-process` 的受限令牌路径中增加 Win32 常量，并仅在 `spawnInheritedJobProcess` 使用它：
+
+```js
+/** Process creation flag that prevents a sandboxed console process from opening a window. */
+const CREATE_NO_WINDOW = 0x08000000;
+
+function spawnInheritedJobProcess(api, options) {
+  const commandLine = buildCommandLine(options.command, options.args);
+  return spawnJobProcess(
+    api,
+    options,
+    () => inheritedStandardHandles(api),
+    "CreateProcessAsUserW",
+    (startupInfo, processInfo) =>
+      createRestrictedProcess(
+        api,
+        options,
+        commandLine,
+        4 | CREATE_NO_WINDOW,
+        startupInfo,
+        processInfo,
+      ),
+  );
+}
+```
+
+`CREATE_NO_WINDOW` 的正确值是 `0x08000000`。它不是 `80`（十进制）或 `0x50`；把 `1028` 错误改成 `1108` 会启用其他不相关的创建标志，不能作为本问题的修复。
+
+### 方案对比
+
+| 方案 | 是否消除可见窗口 | 控制台关联 | 采用情况 |
+| --- | --- | --- | --- |
+| 保持 `4` | 否 | 保留可见控制台 | 修复前 |
+| `STARTF_USESHOWWINDOW + SW_HIDE` | 是 | 仍创建控制台，仅隐藏显示 | 未采用 |
+| `4 \| CREATE_NO_WINDOW` | 是 | 不创建可见控制台窗口 | 已采用 |
+
+选择 `CREATE_NO_WINDOW` 的原因：
+
+- 修复点就在实际弹窗的受限令牌路径。
+- 不需要修改共享 `STARTUPINFO`，避免改变 GUI 子进程的初始显示行为。
+- 保留挂起创建、Job 绑定、`ResumeThread`、受限令牌和 ACL 权限模型。
+- 不修改普通 `CreateProcessW` 路径；完全权限行为保持不变。
+
+## 实际改动
+
+- `patches/@deepseek-ai+dsh-win32-process+0.1.5-rc.1.patch`
+  - 增加 `CREATE_NO_WINDOW = 0x08000000`。
+  - 仅将 `spawnInheritedJobProcess` 的创建标志改为 `4 | CREATE_NO_WINDOW`。
+  - 保持 `spawnCurrentTokenJobProcess` 的 `1028` 不变。
+- `scripts/fixtures/windows-acl-sandbox-probe.cjs`
+  - 在真实 ACL 沙箱中分别运行 `read-only` 和 `workspace-write`。
+  - 检查 PowerShell 是否出现可见控制台。
+  - 检查工作区内、外的写入权限边界。
+- `test/windows-acl-sandbox.test.js`
+  - 使用捆绑 Electron 和真实 runner 启动 fixture。
+  - 在存在 PowerShell 7 时同时覆盖 `powershell.exe` 与 `pwsh.exe`。
+
+本次没有增加 `dsh-subprocess-local` 补丁，也没有修改桌面 JavaScript、权限策略或 ACL 实现。
+
+## 验证结果
+
+### 真实沙箱回归
+
+在修复前，`read-only` 和 `workspace-write` 均能复现可见 PowerShell 控制台。加入 `4 | CREATE_NO_WINDOW` 后：
+
+| 权限模式 | 工作区内写入 | 工作区外写入 | 可见控制台 | 退出码 |
+| --- | --- | --- | --- | --- |
+| `read-only` | 被拒绝 | 被拒绝 | 否 | 正常 |
+| `workspace-write` | 成功 | 被拒绝 | 否 | 正常 |
+
+### 自动化命令
+
+```sh
+npm ci --no-audit --no-fund
+node --test test/windows-acl-sandbox.test.js
+npm test
+npm run check
+```
+
+验证结果：
+
+- 干净安装成功应用新 patch。
+- `node --test test/windows-acl-sandbox.test.js`：1/1 通过。
+- `npm test`：97/97 通过。
+- `npm run check`：通过。
+- 安装目录中的依赖文件已替换为与仓库验证版本逐字节一致的版本。
+- 用户在本机 DSH Desktop 的 `read-only`、`workspace-write` 和“完全权限”三种模式下完成人工验收，确认前两种不再弹窗，完全权限行为不变。
+
+## 剩余风险
+
+- 该修复通过 `patch-package` 应用于固定版本 `@deepseek-ai/*@0.1.5-rc.1`。应用更新或重新安装 DSH Desktop 后，安装目录可能被覆盖，需要重新应用或升级到包含上游修复的版本。
+- `CREATE_NO_WINDOW` 改变的是控制台窗口的创建行为。依赖可见控制台的第三方控制台程序可能需要单独兼容性验证；本次已验证 PowerShell 5.1、PowerShell 7、stdio 管道、退出码和 Job 生命周期。
+- 回归测试覆盖 PowerShell；更广泛的终端程序、GUI 子进程和其他平台仍由对应 CI 或后续验收覆盖。
+
+## 参考
+
+- [Microsoft: Process Creation Flags](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags)
+- [Microsoft: STARTUPINFOW](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow)
+- [Microsoft: CreateProcessAsUserW](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessasuserw)
+
+**报告日期**：2026-09-11

--- a/patches/@deepseek-ai+dsh-win32-process+0.1.5-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-win32-process+0.1.5-rc.1.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/@deepseek-ai/dsh-win32-process/lib/index.js b/node_modules/@deepseek-ai/dsh-win32-process/lib/index.js
+index 697e5e4..4a1a80b 100644
+--- a/node_modules/@deepseek-ai/dsh-win32-process/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-win32-process/lib/index.js
+@@ -3,6 +3,8 @@ import koffi from "koffi";
+ const ERROR_INSUFFICIENT_BUFFER = 122;
+ /** Job limit that terminates every member when the final Job handle closes. */
+ const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 8192;
++/** Process creation flag that prevents a sandboxed console process from opening a window. */
++const CREATE_NO_WINDOW = 0x08000000;
+ //#endregion
+ //#region lib/types/errors.js
+ /** Win32 call failure with the exact API name and error code. */
+@@ -601,7 +603,7 @@ function spawnJobProcess(api, options, resolveStdio, createName, create) {
+ */
+ function spawnInheritedJobProcess(api, options) {
+ 	const commandLine = buildCommandLine(options.command, options.args);
+-	return spawnJobProcess(api, options, () => inheritedStandardHandles(api), "CreateProcessAsUserW", (startupInfo, processInfo) => createRestrictedProcess(api, options, commandLine, 4, startupInfo, processInfo));
++	return spawnJobProcess(api, options, () => inheritedStandardHandles(api), "CreateProcessAsUserW", (startupInfo, processInfo) => createRestrictedProcess(api, options, commandLine, 4 | CREATE_NO_WINDOW, startupInfo, processInfo));
+ }
+ /**
+ * Spawn an ordinary process suspended, assign its Job, then resume it.

--- a/scripts/fixtures/windows-acl-sandbox-probe.cjs
+++ b/scripts/fixtures/windows-acl-sandbox-probe.cjs
@@ -1,0 +1,109 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { join } = require('node:path')
+const koffi = require('koffi')
+const {
+  AclSandbox,
+  tempWriteSid,
+  workspaceWriteSid,
+} = require('@deepseek-ai/dsh-sandbox-windows-acl')
+
+const kernel32 = koffi.load('kernel32.dll')
+const user32 = koffi.load('user32.dll')
+const attachConsole = kernel32.func('__stdcall', 'AttachConsole', 'int', ['uint32'])
+const freeConsole = kernel32.func('__stdcall', 'FreeConsole', 'int', [])
+const getConsoleWindow = kernel32.func('__stdcall', 'GetConsoleWindow', 'void *', [])
+const isWindowVisible = user32.func('__stdcall', 'IsWindowVisible', 'int', ['void *'])
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+const psLiteral = value => value.replaceAll("'", "''")
+
+async function inspectConsole(pid) {
+  const deadline = Date.now() + 3000
+  while (Date.now() < deadline) {
+    if (attachConsole(pid) !== 0) {
+      try {
+        const hwnd = getConsoleWindow()
+        return {
+          attached: true,
+          hasConsole: hwnd !== null,
+          visible: hwnd !== null && isWindowVisible(hwnd) !== 0,
+        }
+      } finally {
+        freeConsole()
+      }
+    }
+    await sleep(25)
+  }
+  return { attached: false, hasConsole: false, visible: false }
+}
+
+async function verifyCase(shell, mode) {
+  const root = mkdtempSync(join(tmpdir(), `dsh windows acl ${mode} `))
+  const workspace = join(root, 'workspace')
+  const privateTemp = join(root, 'temp')
+  const insidePath = join(workspace, 'inside.txt')
+  const outsidePath = join(root, 'outside.txt')
+  mkdirSync(workspace)
+  mkdirSync(privateTemp)
+
+  const sandbox = mode === 'read-only'
+    ? new AclSandbox({ writableDirs: [], tempDir: null, mode })
+    : new AclSandbox({
+        writableDirs: [workspace],
+        tempDir: privateTemp,
+        mode,
+        writeSid: workspaceWriteSid(workspace),
+        tempWriteSid: tempWriteSid(privateTemp),
+      })
+
+  try {
+    await sandbox.init()
+    const command = [
+      `try { Set-Content -LiteralPath '${psLiteral(insidePath)}' -Value ok -ErrorAction Stop } catch {}`,
+      `try { Set-Content -LiteralPath '${psLiteral(outsidePath)}' -Value no -ErrorAction Stop } catch {}`,
+      'Start-Sleep -Milliseconds 2500',
+    ].join('; ')
+    const child = sandbox.spawn({
+      command: shell,
+      args: ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command],
+      cwd: workspace,
+      stdio: 'inherit',
+    })
+
+    const consoleState = await inspectConsole(child.pid)
+    const result = await child.wait()
+    assert.equal(result.exitCode, 0, `${mode} ${shell} should exit successfully`)
+    assert.equal(consoleState.visible, false, `${mode} ${shell} must not show a console window`)
+    assert.equal(existsSync(outsidePath), false, `${mode} ${shell} wrote outside the workspace`)
+    if (mode === 'read-only') {
+      assert.equal(existsSync(insidePath), false, `${mode} ${shell} wrote inside the workspace`)
+    } else {
+      assert.equal(readFileSync(insidePath, 'utf8').trim(), 'ok', `${mode} ${shell} did not write inside the workspace`)
+    }
+  } finally {
+    try {
+      sandbox.dispose()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+}
+
+async function main() {
+  assert.equal(getConsoleWindow(), null, 'Electron host must have no console')
+  const shells = process.argv.slice(2)
+  assert.ok(shells.length > 0, 'At least one PowerShell executable is required')
+  for (const shell of shells) {
+    for (const mode of ['read-only', 'workspace-write']) await verifyCase(shell, mode)
+  }
+  console.log('windows ACL sandbox console and permissions verified')
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/test/windows-acl-sandbox.test.js
+++ b/test/windows-acl-sandbox.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const require = createRequire(import.meta.url)
+const fixture = fileURLToPath(new URL('../scripts/fixtures/windows-acl-sandbox-probe.cjs', import.meta.url))
+
+test('Windows ACL sandbox hides PowerShell consoles without weakening file permissions', {
+  skip: process.platform !== 'win32',
+  timeout: 120_000,
+}, () => {
+  const electron = require('electron')
+  const shells = [
+    join(process.env.SystemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    join(process.env.ProgramFiles, 'PowerShell', '7', 'pwsh.exe'),
+  ].filter(existsSync)
+  assert.ok(shells.length > 0, 'A Windows PowerShell installation is required')
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh acl sandbox regression '))
+  try {
+    const result = spawnSync(electron, [fixture, ...shells], {
+      cwd,
+      shell: false,
+      windowsHide: true,
+      encoding: 'utf8',
+      timeout: 100_000,
+      env: {
+        SystemRoot: process.env.SystemRoot,
+        WINDIR: process.env.SystemRoot,
+        TEMP: cwd,
+        TMP: cwd,
+        PATH: join(process.env.SystemRoot, 'System32'),
+        ELECTRON_RUN_AS_NODE: '1',
+      },
+    })
+    assert.equal(result.error, undefined)
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`)
+    assert.match(result.stdout, /windows ACL sandbox console and permissions verified/)
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 问题

Windows 下 `read-only` / `workspace-write` 权限执行 `pwsh` 会弹出终端窗口，`full access` 不弹。

## 根因

受限权限实际走 ACL 沙箱路径：

`dsh-pwsh-sandbox -> dsh-sandbox-local/windows-acl -> spawnSandboxedInherited -> spawnInheritedJobProcess -> CreateProcessAsUserW(..., 4, ...)`

`4` 仅为 `CREATE_SUSPENDED`，缺少 `CREATE_NO_WINDOW`，且该路径使用继承 stdio，因此控制台程序会创建可见窗口。

之前修改普通 `CreateProcessW` 和 `dsh-subprocess-local` 的 `windowsHide` 都不在实际路径上。

## 修复

仅在受限令牌路径使用 `4 | CREATE_NO_WINDOW (0x08000000)`。普通路径保持 `1028`，不削弱 ACL、受限令牌或 Job 权限边界。

## 验证

- 干净 `npm ci --no-audit --no-fund` 成功应用 patch
- `node --test test/windows-acl-sandbox.test.js` 通过
- `npm test`: 97/97 通过
- `npm run check` 通过
- 真实 ACL 沙箱覆盖 `read-only` / `workspace-write`: 无可见控制台，工作区内/外写入权限边界保持
- 用户在本机安装版三种权限模式完成人工验收

完整报告：`docs/bugs/windows-pwsh-sandbox-console-window.md`